### PR TITLE
Add Stefan to R setup description

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,9 +1,10 @@
 Package: resampling.with
-Title: Resampling statistics by Simon, Nimmo-Smith, Brett
+Title: Resampling statistics by Simon, Brett, van der Walt, Nimmo-Smith
 Version: 0.1
 Authors@R: c(
   person("Julian", "Simon", role="aut"),
   person("Matthew", "Brett", email="matthew.brett@gmail.com", role=c("aut", "cre")),
+  person("Stéfan", "van der Walt", email="stefanv@berkeley.edu", role=c("aut", "cre")),
   person("Ian", "Nimmo-Smith", email="ian.nimmo.smith@gmail.com", role="ctb")
   )
 Depends: R (>= 3.1.0)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: resampling.with
-Title: Resampling statistics by Simon, Brett, van der Walt, Nimmo-Smith
+Title: Resampling statistics by Simon, Brett, Van der Walt, Nimmo-Smith
 Version: 0.1
 Authors@R: c(
   person("Julian", "Simon", role="aut"),

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,7 @@
 # License
 
-All material copyright Julian Lincoln Simon, Ian Nimmo-Smith and Matthew
-Brett.  All rights reserved.
+All material copyright Julian Lincoln Simon, Matthew Brett, Stéfan van der Walt
+and Ian Nimmo-Smith.  All rights reserved.
 
 We release the text and figures for this book under a [CC-BY-ND
 license](https://creativecommons.org/licenses/by-nd/4.0).

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 Material for updated (third) edition of [Resampling: The New Statistics,
 second edition](http://www.resample.com/intro-text-online) by Julian L. Simon.
 
-The new edition is by Julian L. Simon with Ian Nimmo-Smith and Matthew Brett.
+The new edition is by Julian L. Simon with Matthew Brett, Stéfan van der Walt
+and Ian Nimmo-Smith.
 
 The latest version will always be at the [book
 website](https://resampling-stats.github.io/resampling-with).

--- a/source/index.Rmd
+++ b/source/index.Rmd
@@ -1,7 +1,8 @@
 ---
 knit: "bookdown::render_book"
 title: "Resampling statistics"
-author: ["Julian Lincoln Simon", "Ian Nimmo-Smith", "Matthew Brett"]
+author: ["Julian Lincoln Simon", "Matthew Brett",
+         "Stéfan van der Walt", "Ian Nimmo-Smith"]
 description: "Resampling statistics"
 url: "https://resampling-stats.github.io/resampling-with"
 github-repo: resampling-stats/resampling-with

--- a/source/preface_third.md
+++ b/source/preface_third.md
@@ -6,6 +6,9 @@
 * The rise of resampling in data science
 * Programming and statistics
 
-Ian Nimmo-Smith
 
 Matthew Brett
+
+Stéfan van der Walt
+
+Ian Nimmo-Smith


### PR DESCRIPTION
This just adds Stefan to the metadata for the R package that has the setup
configuration.  This is build configuration.