### PR TITLE
Edit resampling with code2

### DIFF
--- a/source/index.Rmd
+++ b/source/index.Rmd
@@ -1,5 +1,5 @@
 <!---
-Var substitution interferes with numberirng.
+Var substitution interferes with numbering.
 -->
 ::: r
 ## R edition {.unnumbered}

--- a/source/resampling_method.Rmd
+++ b/source/resampling_method.Rmd
@@ -292,25 +292,29 @@ rnd = np.random.default_rng()
 Here are some examples of the random operations we can perform with
 NumPy:
 
-1.  Make a random choice between three words:
+1. Make a random choice between three words:
 
-    ```{python}
-    rnd.choice(['apple', 'orange', 'banana'])
-    ```
+   ```{python}
+   rnd.choice(['apple', 'orange', 'banana'])
+   ```
 
-2.  Make five random choices of three words, using the "size=" argument:
+2. Make five random choices of three words, using the "size=" argument:
 
-    ```{python}
-    rnd.choice(['apple', 'orange', 'banana'], size=5)
-    ```
+   ```{python}
+   rnd.choice(['apple', 'orange', 'banana'], size=5)
+   ```
 
-3.  Shuffle a list of numbers:
+3. Shuffle a list of numbers:
 
-    ```{python}
-    rnd.permutation([1, 2, 3, 4, 5])
-    ```
-:::
+   ```{python}
+   rnd.permutation([1, 2, 3, 4, 5])
+   ```
 
+4. Generate five random numbers between 1 and 10:
+
+   ```{python}
+   rnd.integers(1, 11, size=5)
+   ```
 :::
 
 Recall that we want twenty 10-sided dice — one per ambulance.  Our dice should
@@ -388,14 +392,14 @@ sum(a == 9)
 
 What exactly happens here under the hood?  First `a == 9` creates an sequence
 of values that only contains
-{{< var true_val >}} or {{< var false_val >}}
+{{< var true >}} or {{< var false >}}
 values, depending on whether each element is equal to 9 or not.
 
-Then, we ask {{< var lang >}} to add up (`sum`) only the {{< var true_val >}}
+Then, we ask {{< var lang >}} to add up (`sum`) only the {{< var true >}}
 elements in that sequence.
 
-{{< var lang >}} counts {{< var true_val >}} as 1, and {{< var false_val >}}
-as 0; thus we can use `sum` to count the number of {{< var false_val >}}
+{{< var lang >}} counts {{< var true >}} as 1, and {{< var false >}}
+as 0; thus we can use `sum` to count the number of {{< var false >}}
 values.
 
 This comes down to asking "how many elements in `a` are equal to 9".

--- a/source/resampling_with_code.Rmd
+++ b/source/resampling_with_code.Rmd
@@ -261,8 +261,8 @@ some_numbers <- c(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
 some_numbers
 ```
 
-Notice that the value for `some_numbers` is a[n]{.python} {{< var array
->}}, and that this value *contains* 10 numbers.
+Notice that the value for `some_numbers` is {{< var an_array >}},
+and that this value *contains* 10 numbers.
 
 Put another way, `some_numbers` is now the name we can use for this collection
 of 10 values.
@@ -438,8 +438,8 @@ a
 ```
 
 As you can see, the function sent back (returned) 17 numbers.  Because it is
-sending back more than one number, the thing it sends back is a[n]{.python} {{<
-var array >}}, where the {{< var array >}} has 17 elements.
+sending back more than one number, the thing it sends back is
+{{< var an_array >}}, where the {{< var array >}} has 17 elements.
 
 ## Counting results
 
@@ -498,9 +498,9 @@ p > 0
 ```
 
 So far you have seen the results of comparison on a single number.  Now say we
-do the same comparison on a[n]{.python} {{< var array >}}.  For example,
+do the same comparison on {{< var an_array >}}.  For example,
 say we ask the question "is the value of `a` greater than 0"?  Remember, `a` is
-a[n]{.python} {{< var array >}} containing 17 values.  We are comparing 17
+{{< var an_array >}} containing 17 values.  We are comparing 17
 values to one value (0). What answer do you think {{< var np_or_r >}} will
 give?  You may want to think a little about this before you read on.
 
@@ -532,7 +532,7 @@ a > 0
 
 There are 17 values in `a`, so the comparison to 0 means there are 17
 comparisons, and 17 answers. {{< var np_or_r >}} therefore returns
-a[n]{.python} *{{< var array >}}* of 17 elements, containing these 17
+ *{{< var an_array >}}* of 17 elements, containing these 17
 answers.  The first answer is the answer to the question "is the value of the
 *first* element of `a` greater than 0", and the second is the answer to "is the
 value of the *second* element of `a` greater than 0".
@@ -568,8 +568,8 @@ As you can imagine,
 [`sum`]{.r}[`np.sum`]{.python}
 adds up all the elements in {{< var an_array >}}, to give a single
 number. This will work as we want for the `q` {{< var array >}}, because
-{{< var lang >}} counts {{< var false >}} as equal to 0 and {{< var
-true_val >}} as equal to 1:
+{{< var lang >}} counts {{< var false >}} as equal to 0 and {{< var true >}}
+as equal to 1:
 
 ```{python, opts.label="py_ed"}
 # Question: is False equal to 0?
@@ -688,7 +688,7 @@ not explain the counts {{< var array >}} of the `for` loop in any detail, becaus
 
 Let us now imagine that we want to do 100 simulated trials at Saint Hypothetical General.  This will give us 100 counts.  We will want to store the count for each trial.
 
-To do this, we make a[n]{.python} {{< var array >}} called `z` to hold the
+To do this, we make {{< var an_array >}} called `z` to hold the
 100 counts.  We have called the {{< var array >}} `z`, but we could have
 called it anything we liked, such as `counts` or `results` or `cecilia`.
 
@@ -800,7 +800,7 @@ comparing two values — here the value in `s`
 and the value 17.  This comparison, like all comparisons, returns an answer
 that is either {{< var true >}} or {{< var false >}}.  In our case `s`
 has the value 17, so the comparison becomes `17 == 17`, meaning "is 17 equal to
-17", to which the answer is Yes, and {lang sends back {{< var true >}}.
+17?", to which the answer is "Yes", and {{< var lang >}} sends back {{< var true >}}.
 ::::::
 
 We can ask this question of *all 100 counts* by asking the question: is the {{<

--- a/source/resampling_with_code.Rmd
+++ b/source/resampling_with_code.Rmd
@@ -57,7 +57,7 @@ In this chapter, we will model another problem using
   * *Comparing* numbers to other numbers.
   * *Counting* numbers that match a condition.
 
-In the next chapter, we will talk more about *using {{< var array_name >}}s* to
+In the next chapter, we will talk more about *using {{< var array >}}s* to
 store results, and *for loops* to repeat a procedure many times.
 
 ## Statistics and probability
@@ -215,7 +215,7 @@ rnd = np.random.default_rng()
 ```
 :::
 
-## From numbers to {{< var array_name >}}s
+## From numbers to {{< var array >}}s
 
 We [next]{.python} need to prepare the *sequence* of numbers that we want
 {{< var np_or_r >}} to select from.
@@ -237,14 +237,14 @@ a
 ```
 
 {{< var np_or_r >}} also allows *values* that are *sequences of numbers*.  {{<
-var np_or_r >}} calls these sequences *{{< var array_name >}}s*.
+var np_or_r >}} calls these sequences *{{< var array >}}s*.
 
 ::: r
 The name *vector* sounds rather technical and mathematical, but the only
 important idea for us is that a *vector* stores a *sequence* of numbers.
 :::
 
-Here we make a {{< var array_name >}} that contains the 10 numbers we will
+Here we make a {{< var array >}} that contains the 10 numbers we will
 select from:
 
 ```{python, opts.label="py_ed"}
@@ -261,13 +261,13 @@ some_numbers <- c(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
 some_numbers
 ```
 
-Notice that the value for `some_numbers` is a[n]{.python} {{< var array_name
+Notice that the value for `some_numbers` is a[n]{.python} {{< var array
 >}}, and that this value *contains* 10 numbers.
 
 Put another way, `some_numbers` is now the name we can use for this collection
 of 10 values.
 
-{{< var array_name >}}s are very useful for simulations and data analysis, and
+{{< var array >}}s are very useful for simulations and data analysis, and
 we will be using these for nearly every example in this book.
 
 ## Functions {#sec-functions-production}
@@ -391,7 +391,7 @@ round(3.2)
 round(-2.7)
 ```
 
-## Sampling from {{< var array_name >}}s
+## Sampling from {{< var array >}}s
 
 In the code above, we asked [`rnd.choice`]{.python}[the `sample` function]{.r}
 to select a single number at random.
@@ -439,7 +439,7 @@ a
 
 As you can see, the function sent back (returned) 17 numbers.  Because it is
 sending back more than one number, the thing it sends back is a[n]{.python} {{<
-var array_name >}}, where the {{< var array_name >}} has 17 elements.
+var array >}}, where the {{< var array >}} has 17 elements.
 
 ## Counting results
 
@@ -448,7 +448,7 @@ the basis for one simulated trial in our simulated world of Saint Hypothetical
 General.
 
 Our next job is to get the code to count the number of numbers that are not
-zero in the {{< var array_name >}} `a`.  That will give us the number of
+zero in the {{< var array >}} `a`.  That will give us the number of
 patients who were cured in our simulated trial.
 
 Another way of asking this question, is to ask how many elements in `a` are
@@ -477,11 +477,11 @@ n > 0
 it. In this case `>` is asking the question "is the value of `n` (on the left
 hand side) greater than 0 (on the right hand side)?" The value of `n` is 5, so
 the question becomes, "is 5 greater than 0?"  The answer is Yes, and {{< var
-lang >}} represents this Yes answer as the value {{< var true_val >}}.
+lang >}} represents this Yes answer as the value {{< var true >}}.
 
 In contrast, the comparison below boils down to "is 0 greater than 0?", to
 which the answer is No, and {{< var lang >}} represents this as
-{{< var false_val >}}.
+{{< var false >}}.
 
 ```{python, opts.label="py_ed"}
 p = 0
@@ -498,9 +498,9 @@ p > 0
 ```
 
 So far you have seen the results of comparison on a single number.  Now say we
-do the same comparison on a[n]{.python} {{< var array_name >}}.  For example,
+do the same comparison on a[n]{.python} {{< var array >}}.  For example,
 say we ask the question "is the value of `a` greater than 0"?  Remember, `a` is
-a[n]{.python} {{< var array_name >}} containing 17 values.  We are comparing 17
+a[n]{.python} {{< var array >}} containing 17 values.  We are comparing 17
 values to one value (0). What answer do you think {{< var np_or_r >}} will
 give?  You may want to think a little about this before you read on.
 
@@ -532,7 +532,7 @@ a > 0
 
 There are 17 values in `a`, so the comparison to 0 means there are 17
 comparisons, and 17 answers. {{< var np_or_r >}} therefore returns
-a[n]{.python} *{{< var array_name >}}* of 17 elements, containing these 17
+a[n]{.python} *{{< var array >}}* of 17 elements, containing these 17
 answers.  The first answer is the answer to the question "is the value of the
 *first* element of `a` greater than 0", and the second is the answer to "is the
 value of the *second* element of `a` greater than 0".
@@ -555,20 +555,20 @@ q <- a > 0
 q
 ```
 
-## Counting {{< var true_val >}} values with `sum`
+## Counting {{< var true >}} values with `sum`
 
-Notice above that there is one {{< var true_val >}} element in `q` for every
+Notice above that there is one {{< var true >}} element in `q` for every
 element in `a` that was greater than 0.  It only remains to *count* the number
-of {{< var true_val >}} values in `q`, to get the count of patients in our
+of {{< var true >}} values in `q`, to get the count of patients in our
 simulated trial who were cured.
 
 We can use the {{< var np_or_r >}} function [`sum`]{.r}[`np.sum`]{.python} to
-count the number of {{< var true_val >}} elements in {{< var a_array_name >}}.
+count the number of {{< var true >}} elements in {{< var an_array >}}.
 As you can imagine,
 [`sum`]{.r}[`np.sum`]{.python}
-adds up all the elements in {{< var a_array_name >}}, to give a single
-number. This will work as we want for the `q` {{< var array_name >}}, because
-{{< var lang >}} counts {{< var false_val >}} as equal to 0 and {{< var
+adds up all the elements in {{< var an_array >}}, to give a single
+number. This will work as we want for the `q` {{< var array >}}, because
+{{< var lang >}} counts {{< var false >}} as equal to 0 and {{< var
 true_val >}} as equal to 1:
 
 ```{python, opts.label="py_ed"}
@@ -595,13 +595,13 @@ FALSE == 0
 TRUE == 1
 ```
 
-Therefore, the function `sum`, when applied to {{< var a_array_name >}} of
-{{< var true_val >}} and {{< var false_val >}}
-values, will count the number of {{< var true_val >}} values in the {{< var
+Therefore, the function `sum`, when applied to {{< var an_array >}} of
+{{< var true >}} and {{< var false >}}
+values, will count the number of {{< var true >}} values in the {{< var
 array_name >}}.
 
-To see this in action we can make a new {{< var array_name >}} of
-{{< var true_val >}} and {{< var false_val >}}
+To see this in action we can make a new {{< var array >}} of
+{{< var true >}} and {{< var false >}}
 values, and try using
 [`sum`]{.r}[`np.sum`]{.python}
 on the new array.
@@ -620,12 +620,12 @@ trues_and_falses <- c(TRUE, FALSE, TRUE, TRUE, FALSE)
 trues_and_falses
 ```
 
-The `sum` operation adds all the elements in the {{< var array_name >}}.
-Because {{< var true_val >}} counts as 1, and {{< var false_val >}} counts as
+The `sum` operation adds all the elements in the {{< var array >}}.
+Because {{< var true >}} counts as 1, and {{< var false >}} counts as
 0, adding all the elements in `trues_and_falses` is the same as adding up the
 values 1 + 0 + 1 + 1 + 0, to give 3.
 
-We can apply the same operation on `q` to count the number of {{< var true_val
+We can apply the same operation on `q` to count the number of {{< var true
 >}} values.
 
 ```{python, opts.label="py_ed"}
@@ -681,15 +681,15 @@ b
 Now we know how to do one simulated trial, we could just keep running the {{< var cell >}} above, and writing down the result each time.  Once we had run the {{< var cell >}} 100 times, we would have 100 counts.  Then we could look at the 100 counts to see how many were equal to 17 (all 17 simulated patients cured on that trial).  At least that would be much faster than rolling 17 dice 100 times, but we would also like the computer to automate the process of repeating the trial, and keeping track of the counts.
 
 Please forgive us as we race ahead again, as we did in the last chapter.  As in
-the last chapter, we will use a *results* {{< var array_name >}} called `z` to
+the last chapter, we will use a *results* {{< var array >}} called `z` to
 store the count for each trial.  As in the last chapter, we will use a `for`
 loop to repeat the trial procedure many times.  As in the last chapter, we will
-not explain the counts {{< var array_name >}} of the `for` loop in any detail, because we are going to cover those in the next chapter.
+not explain the counts {{< var array >}} of the `for` loop in any detail, because we are going to cover those in the next chapter.
 
 Let us now imagine that we want to do 100 simulated trials at Saint Hypothetical General.  This will give us 100 counts.  We will want to store the count for each trial.
 
-To do this, we make a[n]{.python} {{< var array_name >}} called `z` to hold the
-100 counts.  We have called the {{< var array_name >}} `z`, but we could have
+To do this, we make a[n]{.python} {{< var array >}} called `z` to hold the
+100 counts.  We have called the {{< var array >}} `z`, but we could have
 called it anything we liked, such as `counts` or `results` or `cecilia`.
 
 ```{python, opts.label="py_ed"}
@@ -794,17 +794,17 @@ The code `s == 17` has a completely different meaning.
 
 The *double equals* `==` above is a *comparison* in R.
 :::
-It means "give {{< var true_val >}} if the value in `s` is equal to 17, and {{<
-var false_val >}} otherwise".  The `==` is a *comparison* operator — it is for
+It means "give {{< var true >}} if the value in `s` is equal to 17, and {{<
+var false >}} otherwise".  The `==` is a *comparison* operator — it is for
 comparing two values — here the value in `s`
 and the value 17.  This comparison, like all comparisons, returns an answer
-that is either {{< var true_val >}} or {{< var false_val >}}.  In our case `s`
+that is either {{< var true >}} or {{< var false >}}.  In our case `s`
 has the value 17, so the comparison becomes `17 == 17`, meaning "is 17 equal to
-17", to which the answer is Yes, and {lang sends back {{< var true_val >}}.
+17", to which the answer is Yes, and {lang sends back {{< var true >}}.
 ::::::
 
 We can ask this question of *all 100 counts* by asking the question: is the {{<
-var array_name >}} `z` equal to 17, like this:
+var array >}} `z` equal to 17, like this:
 
 ```{python, opts.label="py_ed"}
 # Is the value of z equal to 17?
@@ -820,7 +820,7 @@ were_cured <- z == 17
 were_cured
 ```
 
-Finally we use `sum` to count the number of {{< var true_val >}} values in the `were_cured` {{< var array_name >}}, to give the number of trials where all 17 patients were cured.
+Finally we use `sum` to count the number of {{< var true >}} values in the `were_cured` {{< var array >}}, to give the number of trials where all 17 patients were cured.
 
 ```{python, opts.label="py_ed"}
 # Count the number of True values in "were_cured"

--- a/source/resampling_with_code2.Rmd
+++ b/source/resampling_with_code2.Rmd
@@ -46,7 +46,7 @@ The US Supreme Court rejected this argument, in a 6 to 3 opinion, writing that
 "The overall percentage disparity has been small and reflects no studied
 attempt to include or exclude a specified number of Negros.".
 
-And while the courts heard a lot of evidence on bias in jury selection, one observation made by Swain and his team stands out: that Swain's own jury was *entirely* White.
+Swain's team presented a lot of evidence on bias in jury selection, but here we will look at the obvious and apparently surprising fact that Swain's jury was entirely White.
 The Supreme Court decided that the "disparity" between selection of White and Black jurors "has been small" — but how would they, and how would we, make a rational decision about whether this disparity *really* was "small"?
 
 ## A small disparity and a hypothetical world

--- a/source/resampling_with_code2.Rmd
+++ b/source/resampling_with_code2.Rmd
@@ -658,7 +658,7 @@ To do this, we can ask {{< var an_array >}} which elements match a certain condi
 
 ```{python}
 x = np.array([0, 1, 2, 3])
-mask = (x < 2)
+mask = x < 2
 print(mask)
 
 # Select elements that match True values in mask
@@ -667,7 +667,7 @@ print(x[mask])
 
 ```{r}
 x <- c(0, 1, 2, 3)
-mask = (x < 2)
+mask = x < 2
 print(mask)
 print(x[mask])
 ```
@@ -676,14 +676,14 @@ We now use that same technique to ask, of *each of the 100 counts*, whether the 
 
 ```{python, opts.label="py_ed"}
 # Is the value of z equal to 0?
-all_white = (z == 0)
+all_white = z == 0
 # Show the result of the comparison.
 all_white
 ```
 
 ```{r, opts.label="r_ed"}
 # Is the value of z equal to 0?
-all_white <- (z == 0)
+all_white <- z == 0
 # Show the result of the comparison.
 all_white
 ```

--- a/source/resampling_with_code2.Rmd
+++ b/source/resampling_with_code2.Rmd
@@ -289,7 +289,7 @@ knowing more about them.
 
 A [NumPy array]{.python}[vector]{.r} is a *container* that stores many
 elements of the same type.  You have already seen, in @sec-resampling-method,
-how we can create a[n]{.python} {{< var array >}} from a sequence of
+how we can create {{< var an_array >}} from a sequence of
 numbers using the [`np.array`]{.python}[`c()`]{.r} function.
 
 ```{python, opts.label="py_ed"}
@@ -331,7 +331,7 @@ that the function will return.
 
 The are various useful things we can do with this {{< var array >}} container.
 One is to ask how many elements there are in the {{< var array >}} container.
-We can use the [`len`]{.python}[`length`]{.r} function to calculate the number of elements in a[n]{.python} {{< var array >}}:
+We can use the [`len`]{.python}[`length`]{.r} function to calculate the number of elements in {{< var an_array >}}:
 
 ```{python, opts.label="py_ed"}
 # Show the number of elements in "z"
@@ -567,7 +567,7 @@ for (i in numbers) {
 ```
 
 When we want to count to a hundred, it becomes laborious to type out the
-numbers. For that, {{< var lang> }} has a shorthand [called `range`]{.python}—very similar to NumPy's `arange`]{.python}:
+numbers. For that, {{< var lang> }} has a shorthand [called `range`—very similar to NumPy's `arange`]{.python}:
 
 ```{python, opts.label="py_ed"}
 for i in range(5):
@@ -654,7 +654,25 @@ z
 
 Finally, we need to count how many of the trials in `z` ended up with all-White juries.  These are the trials with a `z` value of 0.
 
-We can ask this question of *all 100 counts* by asking the question: is the {{< var array >}} `z` equal to 0, like this:
+To do this, we can ask {{< var an_array >}} which elements match a certain condition.  E.g.:
+
+```{python}
+x = np.array([0, 1, 2, 3])
+mask = (x < 2)
+print(mask)
+
+# Select elements that match True values in mask
+print(x[mask])
+```
+
+```{r}
+x <- c(0, 1, 2, 3)
+mask = (x < 2)
+print(mask)
+print(x[mask])
+```
+
+We now use that same technique to ask, of *each of the 100 counts*, whether the {{< var array >}} `z` is equal to 0, like this:
 
 ```{python, opts.label="py_ed"}
 # Is the value of z equal to 0?

--- a/source/resampling_with_code2.Rmd
+++ b/source/resampling_with_code2.Rmd
@@ -27,7 +27,7 @@ source("_common.R")
 
 @sec-resampling-code introduced a problem in probability, that was also a problem in statistics.  We asked how surprised we should be at the results of a trial of a new cancer treatment regime.
 
-Here we study another urgent problem in the real world—racial bias and the
+Here we study another urgent problem in the real world - racial bias and the
 death penalty.
 
 ## A question of life and death
@@ -41,7 +41,7 @@ the eligible jurors in that county were Black, but every member of Swain's
 jury was White.  Swain and his legal team appealed to the Alabama Supreme
 Court, and then to the [US Supreme
 Court](https://en.wikipedia.org/wiki/Swain_v._Alabama), arguing
-that Black jurors were very rarely selected for juries in Talladegna county, even though they made up about a quarter of the eligible pool of jurors.
+that Black jurors were very rarely selected for juries in Talladega county, even though they made up about a quarter of the eligible pool of jurors.
 The US Supreme Court rejected this argument, in a 6 to 3 opinion, writing that
 "The overall percentage disparity has been small and reflects no studied
 attempt to include or exclude a specified number of Negros.".
@@ -58,7 +58,7 @@ person had an equal chance of being selected for the jury.  Call this world Hypo
 
 Just as in 1960's Talladega County, 26% of eligible jurors in Hypothetical
 County are Black.  Hypothetical County jury selection has no bias against
-Black men, so we expect around 26% of the jury to be Black. 0.26 * 12 =
+Black people, so we expect around 26% of the jury to be Black. 0.26 * 12 =
 3.12, so we expect that, on average, just over 3 out of 12 jurors in
 a Hypothetical County jury will be Black.  But, if we select each juror at
 random from the population, that means that, sometimes, by chance, we will have
@@ -99,7 +99,7 @@ Now comes the harder part.  How do we simulate one trial?
 ### One trial
 
 One trial requires 12 jurors, and we are interested only in the race of each juror.
-In our hypothesized world, where selection by race is entirely random, each juror
+In Hypothetical County, where selection by race is entirely random, each juror
 has a 26% chance of being Black.
 
 We need a way of simulating a 26% chance.

--- a/source/resampling_with_code2.Rmd
+++ b/source/resampling_with_code2.Rmd
@@ -25,9 +25,9 @@ source("_common.R")
 
 # More resampling with code
 
-@sec-resampling code introduced a problem in probability, that was also a problem in statistics.  We asked how surprised we should be the results of a trial of a new cancer treatment regime.
+@sec-resampling-code introduced a problem in probability, that was also a problem in statistics.  We asked how surprised we should be at the results of a trial of a new cancer treatment regime.
 
-Here we study another urgent problem in the real world - racial bias and the
+Here we study another urgent problem in the real world—racial bias and the
 death penalty.
 
 ## A question of life and death
@@ -40,62 +40,66 @@ Robert Swain was a young Black man who was sentenced to death in the early
 the eligible jurors in that county were Black, but every member of Swain's
 jury was White.  Swain and his legal team appealed to the Alabama Supreme
 Court, and then to the [US Supreme
-Court](https://en.wikipedia.org/wiki/Swain_v._Alabama), arguing there was
-that Black jurors were very rarely selected for juries in Talladega county, even though they made up about a quarter of the eligible pool of jurors.
+Court](https://en.wikipedia.org/wiki/Swain_v._Alabama), arguing
+that Black jurors were very rarely selected for juries in Talladegna county, even though they made up about a quarter of the eligible pool of jurors.
 The US Supreme Court rejected this argument, in a 6 to 3 opinion, writing that
 "The overall percentage disparity has been small and reflects no studied
 attempt to include or exclude a specified number of Negros.".
 
-The courts heard a lot of evidence on this bias in selection, but one
-observation that Swain and his team made, was that Swain's own jury was
-entirely White. To make our task simpler, we will only look at the composition
-of Swain's jury.
-
-The Supreme Court decided that the "disparity" between selection of White and
-Black jurors "has been small" — but how would they, and how would we, make a rational decision about whether this disparity really was "small"?
+And while the courts heard a lot of evidence on bias in jury selection, one observation made by Swain and his team stands out: that Swain's own jury was *entirely* White.
+The Supreme Court decided that the "disparity" between selection of White and Black jurors "has been small" — but how would they, and how would we, make a rational decision about whether this disparity *really* was "small"?
 
 ## A small disparity and a hypothetical world
 
 To answer the question that the Supreme Court asked, we return to the method we used in the last chapter.
 
-Let us imagine a hypothetical world, where each individual Black or White
-jurors had an equal chance of being selected for the jury.  Call this world Hypothetical County, Alabama.
+Let us imagine a hypothetical world, in which each individual Black or White
+person had an equal chance of being selected for the jury.  Call this world Hypothetical County, Alabama.
 
-Just as in 1960's Talladega County, 26% of the eligible jurors in Hypothetical
+Just as in 1960's Talladega County, 26% of eligible jurors in Hypothetical
 County are Black.  Hypothetical County jury selection has no bias against
-Black men, so we expect around 26% of the jury will be Black. 0.26 * 12 =
-3.12, so we expect that, on average, a little more than 3 out of 12 jurors in
+Black men, so we expect around 26% of the jury to be Black. 0.26 * 12 =
+3.12, so we expect that, on average, just over 3 out of 12 jurors in
 a Hypothetical County jury will be Black.  But, if we select each juror at
-random from the population, that means that sometimes, by chance, we will have
+random from the population, that means that, sometimes, by chance, we will have
 fewer than 3 Black jurors, and sometimes will have more than 3 Black jurors.
 And, by chance, sometimes we will have no Black jurors.  But, if the jurors
 really are selected at random, how often would we expect this to happen — that
-there are no Black jurors.  We would like to estimate the *probability* that
+there are no Black jurors?  We would like to estimate the *probability* that
 we will get no Black jurors.  If that probability is small, then we have some
 evidence that the disparity in selection between Black and White jurors, was
 not "small".
 
-## One trial
+::: {.question}
+What is the probability of an *all White* jury being randomly selected out of a population having 26% Black people?
+:::
 
-Remember the six steps:
+## Designing the experiment
 
-1. *We decide what we mean by one trial*.
-2. Work out the *outcome* of interest from the trial.
-2. Work out how to *simulate one trial*.
-3. *Repeat* the simulated trial procedure.
-4. *Count* the number of trials with an outcome that matches the outcome we
+Before we start, we need to figure out three things:
+
+1. What do we mean by one trial?
+2. What is the outcome of interest from the trial?
+3. How do we simulate one trial?
+
+We then take **three steps** to calculate the desired probability:
+
+1. *Repeat* the simulated trial procedure N times.
+2. *Count* M, the number of trials with an outcome that matches the outcome we
    are interested in.
-5. Calculate the *proportion*.
+3. Calculate the *proportion*, M/N.
+   This is an estimate of the probability in question.
 
-Are task in step 1 is made a little easier by the fact that our *trial* (in the resampling sense) is a simulated *trial* (in the legal sense).
+For this problem, our task is made a little easier by the fact that our *trial* (in the resampling sense) is a simulated *trial* (in the legal sense). One trial requires 12 simulated jurors, each labeled by race (White or Black).
 
-One trial, is 12 simulated jurors, each labeled by race (White or Black). For
-step 2, the outcome we are interested in is the number of Black jurors.
+The outcome we are interested in is the number of Black jurors.
 
 Now comes the harder part.  How do we simulate one trial?
 
-One trial is 12 jurors, and we are interested only the race of each juror.  In
-our hypothesized world, where selection by race is entirely random, each juror
+### One trial
+
+One trial requires 12 jurors, and we are interested only in the race of each juror.
+In our hypothesized world, where selection by race is entirely random, each juror
 has a 26% chance of being Black.
 
 We need a way of simulating a 26% chance.
@@ -104,7 +108,7 @@ One way of doing this is by getting a random number from 0 through 99
 (inclusive).  There are 100 number in the range 0 through 99 (inclusive).
 
 ::: {.callout-note}
-## Pick a number from 1 through 5
+#### Pick a number from 1 through 5
 
 Ranges can be confusing in normal speech because it is not always clear
 whether they include their beginning and end.  For example, if someone says
@@ -117,7 +121,7 @@ To avoid this confusion, we will nearly always use "from" and "through" in
 ranges, meaning that we do include both the start and the end number.  For
 example, if we say "pick a number from 1 through 5" we mean one of 1 or 2 or 3
 or 4 or 5.
-"""
+:::
 
 We will arbitrarily say that the juror is White if the random number is in the
 range from 0 through 73.  74 of the 100 numbers are in this range, so
@@ -135,12 +139,10 @@ the green die has 4, then the random number is 84.
 
 We could then simulate 12 jurors by repeating this process 12 times, each time
 writing down "White" if the number is from 0 through 74, and "Black"
-otherwise.  The trial outcome is the number of times we wrote "Black" of these
+otherwise.  The trial outcome is the number of times we wrote "Black" for these
 12 simulated jurors.
 
-## Using code for simulated trial
-
-::: {.python}
+### Using code to simulate a trial
 
 We use the same logic to simulate a trial with the computer. A little code
 makes the job easier, because we can ask {{< var lang >}} to give us 12 random
@@ -148,9 +150,10 @@ numbers from 0 through 99, and to count how many of these numbers are in the
 range from 75 through 99.  Numbers in the range from 75 through 99 correspond
 to Black jurors.
 
-### Ranges in {{< var lang >}}
+:::: {.callout-note}
+#### Ranges in {{< var lang >}}
 
-We said above, that ranges can be confusing, and we use "from 1 through 5" to avoid this confusion.
+We said above that ranges can be confusing, and we use "from 1 through 5" to avoid this confusion.
 
 ::: {.python}
 Python and NumPy also have the concept of a range of integers (positive or
@@ -169,7 +172,7 @@ some_numbers
 
 Notice that `np.arange(0, 6)` means "from 0 through 5" — the range *does not
 include* the last value.  Another way of putting this is that `np.arange(0,
-6)` means "from 0 up to, but not including 6".
+6)` means "from 0 up to, but not including, 6".
 
 This takes a little getting used to, but we think you will find it starts to
 come naturally after a while.
@@ -191,9 +194,11 @@ Notice that `0:5` means exactly "from 0 through 5" — the range includes all
 the integers starting at 0 and including 5.
 :::
 
-### Random numbers from 0 through 99
+::::
 
-We can now use {{< var np_or_r >}} and the random number function from the last chapter, to get 12 random numbers from 0 through 99.
+#### Random numbers from 0 through 99
+
+We can now use {{< var np_or_r >}} and the random number function from the last chapter to get 12 random numbers from 0 through 99.
 
 ```{python, opts.label="py_ed"}
 # Ask NumPy for a random number generator.
@@ -201,8 +206,7 @@ rnd = np.random.default_rng()
 
 # Get 12 random numbers from 0 through 99
 # (from 0, up to, but not including 100).
-zero_through_99 = np.arange(0, 100)
-a = rnd.choice(zero_through_99, 12)
+a = rnd.integers(0, 100, size=12)
 
 # Show the result
 a
@@ -216,7 +220,7 @@ a <- sample(0:99, 12, replace=TRUE)
 a
 ```
 
-### Counting the jurors
+#### Counting the jurors
 
 We use *comparison* and [`np.sum`]{.python}[`sum`]{.r} to count how
 many numbers are are greater than 74, and therefore, in the range from 75
@@ -231,22 +235,24 @@ b
 
 ```{r, opts.label="r_ed"}
 # How many numbers are greater than 74?
-b <- sum(a == 9)
+b <- sum(a > 74)
 # Show the result
 b
 ```
 
-### A single simulated trial
+#### A single simulated trial
 
-We assemble the pieces from the last few sections to make a {{< var cell >}} that simulated a single trial:
+We assemble the pieces from the last few sections to make a {{< var cell >}} that simulates a single trial:
 
 ```{python, opts.label="py_ed"}
 rnd = np.random.default_rng()
+
 # Get 12 random numbers from 0 through 99
-zero_through_99 = np.arange(0, 100)
-a = rnd.choice(zero_through_99, 12)
+a = rnd.integers(0, 100, size=12)
+
 # How many numbers are greater than 74?
 b = np.sum(a > 74)
+
 # Show the result
 b
 ```
@@ -260,28 +266,31 @@ b <- sum(a > 74)
 b
 ```
 
-## Repeating trials
+## Three simulation steps
 
 Now we come back to the details of how we:
 
-* Repeat the simulated trial many times;
-* Record the results for each trial.
+1. Repeat the simulated trial many times;
+2. record the results for each trial;
+3. calculate the required proportion as an estimate of the probability
+   we seek.
 
 Repeating the trial many times is the job of the `for` loop, and we will come
 to that soon.
 
-In order to record the results, we will store each trial result in an {{< var
-array_name >}}.
+In order to record the results, we will store each trial result in {{< var
+an_array >}}.
 
-### More on {{< var array_name >}}s
+:::{.callout-note}
+### More on {{< var array >}}s
 
-Since we will be working with {{< var array_name >}}s a lot, it is worth
+Since we will be working with {{< var array >}}s a lot, it is worth
 knowing more about them.
 
 A [NumPy array]{.python}[vector]{.r} is a *container* that stores many
 elements of the same type.  You have already seen, in @sec-resampling-method,
-how we can create a[n]{.python} {{< var array_name >}} from a sequence of
-numbers using the [`np.array`]{.python}[`c()`] function.
+how we can create a[n]{.python} {{< var array >}} from a sequence of
+numbers using the [`np.array`]{.python}[`c()`]{.r} function.
 
 ```{python, opts.label="py_ed"}
 # Make an array of numbers, store with the name "some_numbers".
@@ -297,7 +306,7 @@ some_numbers <- c(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
 some_numbers
 ```
 
-Another way that we can create {{< var array_name >}}s is to use the
+Another way that we can create {{< var array >}}s is to use the
 [`np.zeros`]{.python}[`numeric`]{.r} function to make a new array where all
 the elements are 0.
 
@@ -317,10 +326,12 @@ z
 ```
 
 Notice the argument `5` to the [`np.zeros`]{.python}[`integer`]{.r} function.
-This tells the function how many zeros we want in the {{< var array_name >}}
+This tells the function how many zeros we want in the {{< var array >}}
 that the function will return.
 
-The are various useful things we can do with this {{< var array_name >}} container.  One is to ask how many elements there are in the {{< var array_name >}} container.  We can use the [`len`]{.python}[`length`]{.r} function to calculate the number of elements in a[n]{.python} {{< var array_name >}}:
+The are various useful things we can do with this {{< var array >}} container.
+One is to ask how many elements there are in the {{< var array >}} container.
+We can use the [`len`]{.python}[`length`]{.r} function to calculate the number of elements in a[n]{.python} {{< var array >}}:
 
 ```{python, opts.label="py_ed"}
 # Show the number of elements in "z"
@@ -332,9 +343,10 @@ len(z)
 length(z)
 ```
 
-Another thing we can do is *set* the value for a particular element in the {{<
-var array_name >}}.  To do this, we use square brackets following the {{< var
-array_name >}} value, on the left hand side of the equals sign, like this:
+Another thing we can do is *set* the value for a particular element in the
+{{< var array >}}.  To do this, we use square brackets following the
+{{< var array >}} value, on the left hand side of the equals sign,
+like this:
 
 ```{python, opts.label="py_ed"}
 # Set the value of the *first* element in the array.
@@ -351,21 +363,19 @@ z
 ```
 
 Read the first line of code as "the element at position
-[0]{.python}[1]{.r}
-gets the value 99".
+[0]{.python}[1]{.r} gets a value of 99".
 
 ::: python
 Notice that the position number of the first element in the array is 0, and the
-position number of the second element is 1.  Think of the position as a
+position number of the second element is 1.  Think of the position as an
 *offset* from the beginning of the array.  The first element is at the
 beginning of the array, and so it is at offset (position) 0.  This can be a
 little difficult to get used to at first, but you fill find that thinking of
-the positions of offsets in this way soon starts to come naturally, and later,
-you will also find it helps you avoid some common mistakes when using positions
-for getting and setting values.
+the positions of offsets in this way soon starts to come naturally, and later
+you will also find that it helps you to avoid some common mistakes when using positions for getting and setting values.
 :::
 
-For practice, let us also set the value of the third element in the {{< var array_name >}}:
+For practice, let us also set the value of the third element in the {{< var array >}}:
 
 ```{python, opts.label="py_ed"}
 # Set the value of the *third* element in the array.
@@ -400,16 +410,19 @@ v = z[0]
 v
 ```
 
-Read the first code line here as "v gets the value at position 0 in the {{< var array_name >}}.
+Read the first code line here as "v gets the value at position 0 in the {{< var array >}}.
 
 Using square brackets to get and set element values is called *indexing* into
-the {{< var array_name >}}.
+the {{< var array >}}.
+:::
+
+### Repeating trials
 
 As a preview, let us now imagine that we want to do 100 simulated trials of
 Robert Swain's jury.  This will give us 100 counts.  We will want to store the
 count for each trial.
 
-In order to do this, we make a[n]{.python} {{< var array_name >}} to hold the 100 counts.  Call this {{< var array_name >}} `z`.
+In order to do this, we make {{< var an_array >}} to hold the 100 counts.  Call this {{< var array >}} `z`.
 
 ```{python, opts.label="py_ed"}
 # An array to hold the 100 count values.
@@ -430,8 +443,7 @@ different counts.
 ```{python, opts.label="py_ed"}
 rnd = np.random.default_rng()
 # Get 12 random numbers from 0 through 99
-zero_through_99 = np.arange(0, 100)
-a = rnd.choice(zero_through_99, 12)
+a = rnd.integers(0, 100, 12)
 # How many numbers are greater than 74?
 b = np.sum(a > 74)
 # Show the result
@@ -448,7 +460,7 @@ b
 ```
 
 Now we have the result of a single trial, we can store it as the first number
-in the `z` {{< var array_name >}}:
+in the `z` {{< var array >}}:
 
 ```{python, opts.label="py_ed"}
 # Store the single trial count as the first value in the "z" array.
@@ -466,29 +478,21 @@ z
 
 Of course we could just keep doing this: run the {{< var cell >}} corresponding
 to a trial, above, to get a new count, and then store it at the next position
-in the `z` {{< var array_name >}} with:
+in the `z` {{< var array >}} with:
 [`z[1] = count`]{.python}[`z[2] <- count`]{.r},
 and so on, but that also looks like a task that the computer is well-suited
-for.  And indeed it is, because {{< var lang >}} an excellent way of repeating
-the same set of steps many times — the `for` loop.  You have already seen a
+for.  And indeed it is, because {{< var lang >}} has an excellent way of
+repeating the same set of steps many times — the `for` loop.  You have already seen a
 preview of the `for` loop in @sec-resampling-method. Here we dive into them in
 more depth.
 
-## For-loops in {{< var lang >}}
+:::{.callout-box}
+### For-loops in {{< var lang >}}
 
-::: todo
-Need to switch for-loops to use integers rather than strings here.
+<!-- Matthew wants to switch this to integers instead of strings; S needs to find out why -->
 
-Can we get away without "print"?  Probably not, but then, need to introduce
-it.
-:::
-
-Imagine a factory robot that slides along a worktable on which several items
-have been placed.  It services each of these items, one by one, until it is
-done.
-
-So the robot knows *which* item it is operating on, each item is given
-a label.
+Imagine a factory robot in front of a conveyor belt along which several items have been placed.
+It services each of these items, one by one, using the same procedure, until its work is done.
 
 Here is an example:
 
@@ -497,10 +501,19 @@ for item in ['shoe', 'saddle', 'jacket']:
     print('I am stitching a', item)
 ```
 
+```{r}
+items <- c('shoe', 'saddle', 'jacket')
+for (item in items) {
+  message('I am stitching a ', item)
+}
+```
+
 Here, the robot is working its way through three items: a shoe, a saddle, and a jacket.
-As it moves on to each object, it assigns the label ("shoe", "saddle", etc.) to the variable `item`.
-The indented block of code under the for is executed for each item, and in this code block `label` can be accessed.
-The code above can therefore be unpacked into the following equivalent program:
+Every time that a new object arrives in front of it, that object is assigned the label `item`.
+The [indented block of code under]{.python}[block of code inside]{.r} the `for` is executed for each one, and in this code block `label` can be accessed.
+You will also notice us using a new function: [`print`]{.python}[`message`]{.r}. This function receives several arguments, and then prints them out to screen.
+
+The code above can be unpacked into the following equivalent program:
 
 ```{python, opts.label="py_ed"}
 item = 'shoe'
@@ -513,6 +526,17 @@ item = 'jacket'
 print('I am stitching a', item)
 ```
 
+```{r}
+item = 'shoe'
+message('I am stitching a ', item)
+
+item = 'saddle'
+message('I am stitching a ', item)
+
+item = 'jacket'
+message('I am stitching a ', item)
+```
+
 We used the name `item` here, but any other name would do.
 Thus, the following is equivalent:
 
@@ -521,31 +545,51 @@ for package in ['shoe', 'saddle', 'jacket']:
     print('I am stitching a', package)
 ```
 
-It is common to use a number as a label in a for loop:
+```{r}
+items <- c('shoe', 'saddle', 'jacket')
+for (package in items) {
+  message('I am stitching a ', package)
+}
+```
+
+It is also common to operate on numbers in a for loop:
 
 ```{python, opts.label="py_ed"}
 for i in [0, 1, 2, 3, 4]:
     print('The square of', i, 'is', i * i)
 ```
 
+```{r}
+numbers = c(0, 1, 2, 3, 4)
+for (i in numbers) {
+  message('The square of ', i, ' is ', i * i)
+}
+```
+
 When we want to count to a hundred, it becomes laborious to type out the
-numbers. For that, Python has a shorthand called `range`:
+numbers. For that, {{< var lang> }} has a shorthand [called `range`]{.python}—very similar to NumPy's `arange`]{.python}:
 
 ```{python, opts.label="py_ed"}
 for i in range(5):
     print('The square of', i, ' is ', i * i)
 ```
+
+```{r}
+for (i in 0:4) {
+  message('The square of ', i, ' is ', i * i)
+}
+```
+
 :::
 
-## Putting it all together
+### Putting it all together
 
 We found that we could construct the code for a single trial.  Here is the code for a single trial, again:
 
 ```{python, opts.label="py_ed"}
 rnd = np.random.default_rng()
 # Get 12 random numbers from 0 through 99
-zero_through_99 = np.arange(0, 100)
-a = rnd.choice(zero_through_99, 12)
+a = rnd.integers(0, 100, 12)
 # How many numbers are greater than 74?
 b = np.sum(a > 74)
 # Show the result
@@ -561,7 +605,7 @@ b <- sum(a == 9)
 b
 ```
 
-Then we found that we could use {{< var array_name >}}s to store the results
+Then we found that we could use {{< var array >}}s to store the results
 of these trials, and that we could use `for` loops to do many repeats of steps
 like those for a single trial.
 
@@ -610,26 +654,24 @@ z
 
 Finally, we need to count how many of the trials in `z` ended up with all-White juries.  These are the trials with a `z` value of 0.
 
-We can ask this question of *all 100 counts* by asking the question: is the {{< var array_name >}} `z` equal to 0, like this:
+We can ask this question of *all 100 counts* by asking the question: is the {{< var array >}} `z` equal to 0, like this:
 
 ```{python, opts.label="py_ed"}
 # Is the value of z equal to 0?
-all_white = z == 0
+all_white = (z == 0)
 # Show the result of the comparison.
 all_white
 ```
 
 ```{r, opts.label="r_ed"}
 # Is the value of z equal to 0?
-all_white <- z == 0
+all_white <- (z == 0)
 # Show the result of the comparison.
 all_white
 ```
 
-Now we need to get the number of
-[`True`]{.python}[`TRUE`]{.r}
-values in `all_white`, to find how many simulated trials gave all-white
-juries.
+Now we need to get the number of {{< var true >}} values in `all_white`, to find
+how many simulated trials gave all-white juries.
 
 ```{python, opts.label="py_ed"}
 # Count the number of True values in "all_white"

--- a/source/style.css
+++ b/source/style.css
@@ -61,3 +61,16 @@ table caption {
 .lightable-paper {
   width: auto;
 }
+
+.question::before {
+  content: "Question:";
+  font-weight: bold;
+}
+
+.question {
+  border: 1px solid black;
+  background: #F5E1FD;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-top: 1rem;
+}


### PR DESCRIPTION
Now that I've edited this chapter, I'm pretty sure that it is overwhelming i.t.o. the number of detours and details. We already broke this up into two, so I'm wondering what we can do to clarify the flow here.  Perhaps a Python chapter dedicated to ranges and for-loops?  I am conflicted between the approach we have now (weaving Python into chapters) and the one we considered before: a Python primer chapter.  It feels to me that you really don't want all the Python lessons to be interspersed into the flow of the statistics reasoning.  So you want to be able to say something like:

> We will now be using for-loops (Ch X.2) and ranges (Ch. X.3).  If you are not familiar with those, go and study up on them quickly, then come back here.
> E.g., you should understand the following:
> ```
> for i in range(100):
>     print("I squared is", i**2)

If we don't follow that approach, then we should definitely separate them out using callouts (maybe a special callout class specifically for code concepts).  My main concern is that interspersing them will make it hard to *find* them later on, so if we do this we'd need an index of Python/R concepts somewhere anyway.

----
This PR is then a fairly straightforward edit to `resampling_with_code2`.  I renamed some of the variables to make them more natural to call in the text.  The headings are still not quite right: they need better names, and a better structure.