### PR TITLE
Fix for setting version in Quarto templating

### DIFF
--- a/scripts/set_version.py
+++ b/scripts/set_version.py
@@ -35,7 +35,8 @@ def get_parser():
 
 def fill_template(fn, version):
     version = version.lower()
-    variables = QUARTO_VARS[version] | {'version': version}
+    variables = QUARTO_VARS[version]
+    variables['version'] = version
 
     with open(fn, 'rt') as fobj:
         fmt_str = fobj.read()


### PR DESCRIPTION
The | syntax for updating dictionaries does not work for Python 3.8.