### PR TITLE
Use names for knitter settings that Quarto finds acceptable

### DIFF
--- a/source/_common.R
+++ b/source/_common.R
@@ -7,7 +7,7 @@
 options(digits = 3)
 
 knitr::opts_chunk$set(
-  comment = ._spec$knitr$`out-comment`,
+  comment = ._spec$knitr_settings$`out_comment`,
   cache = TRUE,
   out.width = "70%",
   fig.align = 'center',

--- a/source/_quarto.yml.template
+++ b/source/_quarto.yml.template
@@ -45,9 +45,9 @@ filters:
   - noteout-write-notebooks
   - noteout-filter-nb-only
 
-knitr:
+knitr_settings:
   # Comment preceding code output.
-  out-comment: ""
+  out_comment: ""
 
 noteout:
   # Divs, spans to filter before further processing.


### PR DESCRIPTION
Specifically, changed `knittr` field to `knittr_settings` and `out-comment` with `out_comment`.