### PR TITLE
MRG: remove cross-references from prefaces

### DIFF
--- a/source/preface_third.Rmd
+++ b/source/preface_third.Rmd
@@ -38,8 +38,8 @@ this book could fit into your learning and teaching.
 
 ## What Simon saw
 
-Simon gives the early history of this book in the original preface
-(@sec-brief-history).  He starts with the following observation:
+Simon gives the early history of this book in the original preface. He starts
+with the following observation:
 
 > In the mid-1960's, I noticed that most graduate students — among them many
 > who had had several advanced courses in statistics — were unable to apply
@@ -48,10 +48,9 @@ Simon gives the early history of this book in the original preface
 Simon then applied his striking capacity for independent thought to the
 problem — and came to two essential conclusions.
 
-The first was that introductory courses in statistics use far too
-much mathematics. Most students cannot follow along and
-quickly get lost, reducing the subject to  "mumbo-jumbo"
-(@sec-brief-history).
+The first was that introductory courses in statistics use far too much
+mathematics. Most students cannot follow along and quickly get lost, reducing
+the subject to — as Simon puts it — "mumbo-jumbo".
 
 On its own, this was not a new realization.  Simon quotes a classic textbook by
 Wallis and Roberts [-@wallis1956statistics], in which they compare teaching
@@ -59,8 +58,8 @@ statistics through mathematics to teaching in a foreign language.  More
 recently, other teachers of statistics have come to the same conclusion. Cobb
 [-@cobb2007introductory] argues that it is practically impossible to teach
 students the level of mathematics they would need to understand standard
-introductory courses.  It turns out (@sec-resampling-data-science) that he
-also agrees with Simon about the solution.
+introductory courses.  As you will see below, Cobb also agrees with Simon
+about the solution.
 
 Simon's great contribution was to see *how* we can replace the mathematics,
 to better reveal the true heart of statistical thinking.  His starting point


### PR DESCRIPTION
Quarto doesn't handle cross-references between unnamed chapters very
well: see: https://github.com/quarto-dev/quarto-cli/issues/5946