### PR TITLE
Deploy preview build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,3 +66,8 @@ jobs:
 
       - store_artifacts:
           path: _www
+
+workflows:
+  book:
+    jobs:
+      - build-book

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,12 +14,6 @@ jobs:
     steps:
       - checkout
 
-      - run:
-          name: Activate venv
-          command: |
-            python3 -m venv /tmp/venv
-            source /tmp/venv/bin/activate
-
       - restore_cache:
           keys:
             - r-deps-{{ checksum "scripts/install_r_requirements.R" }}
@@ -44,7 +38,11 @@ jobs:
 
       - run:
           name: Install R/Python dependencies
-          command: make build-init
+          command: |
+            python3 -m venv /tmp/venv
+            source /tmp/venv/bin/activate
+
+            make build-init
 
       - save_cache:
           name: "R package cache"
@@ -62,7 +60,9 @@ jobs:
 
       - run:
           name: Build book
-          command: make website
+          command: |
+            source /tmp/venv/bin/activate
+            make website
 
       - store_artifacts:
           path: _www

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,13 @@ jobs:
             - ~/.cache/pip
 
       - run:
+          name: Install quarto and matching pandoc
+          command: |
+            curl -L https://github.com/quarto-dev/quarto-cli/releases/download/v$QUARTO_VER/quarto-$QUARTO_VER-linux-amd64.deb -o quarto.deb
+            curl -L https://github.com/jgm/pandoc/releases/download/$PANDOC_VER/pandoc-$PANDOC_VER-1-amd64.deb -o pandoc.deb
+            sudo dpkg --install quarto.deb pandoc.deb
+
+      - run:
           name: Build book
           command: |
             source /tmp/venv/bin/activate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,68 @@
+# See: https://circleci.com/docs/2.0/language-python/
+
+version: 2.1
+jobs:
+  build-book:
+    docker:
+      - image: cimg/python:3.11.4
+
+    environment:
+      R_LIBS_USER: "~/R_libs:~/R:~/R-dev"
+      QUARTO_VER: "1.4.51"
+      PANDOC_VER: "3.1.2"
+
+    steps:
+      - checkout
+
+      - run:
+          name: Activate venv
+          command: |
+            python3 -m venv /tmp/venv
+            source /tmp/venv/bin/activate
+
+      - restore_cache:
+          keys:
+            - r-deps-{{ checksum "scripts/install_r_requirements.R" }}
+
+      - restore_cache:
+          keys:
+            - pip-deps-{{ checksum "build-requirements.txt" }}
+
+      - run:
+          name: Update apt-get
+          command: |
+            sudo apt-get update
+
+      - run:
+          name: Install system dependencies
+          command: |
+            sudo apt-get install \
+                librsvg2-bin inkscape texlive-xetex \
+                texlive-fonts-extra curl r-base libcurl4-openssl-dev \
+                libssl-dev libxml2-dev libfontconfig1-dev libmagick++-dev
+            R --version | grep 'version '
+
+      - run:
+          name: Install R/Python dependencies
+          command: make build-init
+
+      - save_cache:
+          name: "R package cache"
+          key: r-deps-{{ checksum "scripts/install_r_requirements.R" }}
+          paths:
+            - ~/R
+            - ~/R_libs
+            - ~/R-dev
+
+      - save_cache:
+          name: "Python package cache"
+          key: pip-deps-{{ checksum "build-requirements.txt" }}
+          paths:
+            - ~/.cache/pip
+
+      - run:
+          name: Build book
+          command: make website
+
+      - store_artifacts:
+          path: _www

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,7 +19,7 @@ jobs:
     if: github.repository_owner == 'resampling-stats'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
 
@@ -59,7 +59,7 @@ jobs:
           curl -L https://github.com/jgm/pandoc/releases/download/$PANDOC_VER/pandoc-$PANDOC_VER-1-amd64.deb -o pandoc.deb
           sudo dpkg --install quarto.deb pandoc.deb
 
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -86,14 +86,10 @@ jobs:
         with:
           args: deploy --dir=_www
 
-      - name: Point GitHub status to PR preview
+      - name: Preview URL
         if: github.ref != 'refs/heads/main'
-        uses: Sibz/github-status-action@v1
-        with:
-          authToken: ${{secrets.GITHUB_TOKEN}}
-          state: success
-          context: Preview
-          target_url: ${{ steps.netlify.outputs.NETLIFY_URL }}
+        run: |
+          echo "Preview URL: ${{ steps.netlify.outputs.NETLIFY_URL }}" >> $GITHUB_STEP_SUMMARY
 
       - name: Deploy docs
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -76,29 +76,8 @@ jobs:
       - name: Build book
         run: make website
 
-      - name: Deploy PR to Netlify
-        if: github.ref != 'refs/heads/main'
-        id: netlify
-        uses: South-Paw/action-netlify-cli@2f244b2581e280c8007cabd798708542484bf55a
-        env:
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-          NETLIFY_SITE_ID: ${{ secrets.DEV_NETLIFY_SITE_ID }}
+      - name: Upload book build
+        uses: actions/upload-artifact@v3
         with:
-          args: deploy --dir=_www
-
-      - name: Preview URL
-        if: github.ref != 'refs/heads/main'
-        env:
-          PREVIEW_URL: ${{ steps.netlify.outputs.NETLIFY_DRAFT_URL }}
-        run: |
-          echo "Preview URL: $PREVIEW_URL" >> $GITHUB_STEP_SUMMARY
-
-      - name: Deploy docs
-        if: github.ref == 'refs/heads/main'
-        uses: JamesIves/github-pages-deploy-action@releases/v3
-        with:
-          FOLDER: _www
-          REPOSITORY_NAME: resampling-stats/resampling-with
-          BRANCH: gh-pages
-          SINGLE_COMMIT: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          name: draft-book
+          path: _www

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -79,7 +79,7 @@ jobs:
       - name: Deploy PR to Netlify
         if: github.ref != 'refs/heads/main'
         id: netlify
-        uses: netlify/actions/cli@master
+        uses: South-Paw/action-netlify-cli@2f244b2581e280c8007cabd798708542484bf55a
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.DEV_NETLIFY_SITE_ID }}
@@ -89,7 +89,7 @@ jobs:
       - name: Preview URL
         if: github.ref != 'refs/heads/main'
         env:
-          PREVIEW_URL: ${{ steps.netlify.outputs.NETLIFY_URL }}
+          PREVIEW_URL: ${{ steps.netlify.outputs.NETLIFY_DRAFT_URL }}
         run: |
           echo "Preview URL: $PREVIEW_URL" >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
 
 jobs:
   build-book:
@@ -76,8 +75,11 @@ jobs:
       - name: Build book
         run: make website
 
-      - name: Upload book build
-        uses: actions/upload-artifact@v3
+      - name: Deploy docs
+        uses: JamesIves/github-pages-deploy-action@releases/v3
         with:
-          name: draft-book
-          path: _www
+          FOLDER: _www
+          REPOSITORY_NAME: resampling-stats/resampling-with
+          BRANCH: gh-pages
+          SINGLE_COMMIT: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -88,8 +88,10 @@ jobs:
 
       - name: Preview URL
         if: github.ref != 'refs/heads/main'
+        env:
+          PREVIEW_URL: ${{ steps.netlify.outputs.NETLIFY_URL }}
         run: |
-          echo "Preview URL: ${{ steps.netlify.outputs.NETLIFY_URL }}" >> $GITHUB_STEP_SUMMARY
+          echo "Preview URL: $PREVIEW_URL" >> $GITHUB_STEP_SUMMARY
 
       - name: Deploy docs
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/circleci.yaml
+++ b/.github/workflows/circleci.yaml
@@ -1,0 +1,15 @@
+name: circleci
+
+on: [status]
+jobs:
+  artifact-redirect:
+    runs-on: ubuntu-latest
+    name: Run CircleCI documentation artifact redirector
+    steps:
+      - name: GitHub Action step
+        uses: larsoner/circleci-artifacts-redirector-action@master
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          api-token: ${{ secrets.CIRCLECI_ARTIFACT_REDIRECTOR_TOKEN }}
+          artifact-path: 0/_www/index.html
+          circleci-jobs: build-book


### PR DESCRIPTION
PRs have access to `github.token`, but that token only has read permission.  As such, it cannot be used to update the PR status. Instead, we print the deploy URL to a step output. All step outputs are joined and displayed in the workflow status.