### PR TITLE
Enable jupyter_compat mode

### DIFF
--- a/scripts/install_r_requirements.R
+++ b/scripts/install_r_requirements.R
@@ -31,5 +31,5 @@ fs::dir_create('~/R-dev')  # ?also correct for Windows
 # Install our patched version of reticulate.
 # https://github.com/rstudio/reticulate/pull/1401
 remotes::install_github("rstudio/reticulate",
-                        ref='e8abae30',  # Matplotlib compat merge.
+                        ref='a003118f',  # jupyter-compat fixes.
                         dependencies=TRUE)

--- a/source/_common.R
+++ b/source/_common.R
@@ -18,10 +18,9 @@ knitr::opts_chunk$set(
   fig.asp = 0.618,  # 1 / phi
   fig.show = "hold",
   eval = NA,
-  echo = NA
-  # Do not enable Reticulate jupyter_compat mode for now, see:
-  # https://github.com/rstudio/reticulate/issues/1387
-  # jupyter_compat = TRUE  # Reticulate enable - only show repr for last expr
+  echo = NA,
+  # See: https://github.com/rstudio/reticulate/issues/1387
+  jupyter_compat = TRUE  # Reticulate enable - only show repr for last expr
 )
 
 options(dplyr.print_min = 6, dplyr.print_max = 6)


### PR DESCRIPTION
Latest reticulate should handle jupyter_compat correctly.

See: https://github.com/rstudio/reticulate/pull/1423