### PR TITLE
Simplify logic of option defaults

### DIFF
--- a/source/_common.R
+++ b/source/_common.R
@@ -17,11 +17,21 @@ knitr::opts_chunk$set(
   fig.width = 6,
   fig.asp = 0.618,  # 1 / phi
   fig.show = "hold",
+<<<<<<< Updated upstream
   eval = NA,
   echo = NA
   # Do not enable Reticulate jupyter_compat mode for now, see:
   # https://github.com/rstudio/reticulate/issues/1387
   # jupyter_compat = TRUE  # Reticulate enable - only show repr for last expr
+||||||| Stash base
+  eval = NA,
+  echo = NA,
+  # See: https://github.com/rstudio/reticulate/issues/1387
+  jupyter_compat = TRUE  # Reticulate enable - only show repr for last expr
+=======
+  # See: https://github.com/rstudio/reticulate/issues/1387
+  jupyter_compat = TRUE  # Reticulate enable - only show repr for last expr
+>>>>>>> Stashed changes
 )
 
 options(dplyr.print_min = 6, dplyr.print_max = 6)
@@ -81,7 +91,7 @@ get_var = function(name) {
 
 # See: https://stackoverflow.com/questions/76732162/is-there-a-way-to-detect-the-chunk-language-when-setting-knitr-chunk-options
 set_true_for_matching_lang <- function(options, field) {
-    if (is.na(options[[field]])) {
+    if (!is.logical(options[[field]])) {
       options[[field]] <- (tolower(options$engine) == ._lang)
     }
     return (options)

--- a/source/_common.R
+++ b/source/_common.R
@@ -17,21 +17,13 @@ knitr::opts_chunk$set(
   fig.width = 6,
   fig.asp = 0.618,  # 1 / phi
   fig.show = "hold",
-<<<<<<< Updated upstream
-  eval = NA,
-  echo = NA
+  eval = NULL,  # Emphasizing these are the defaults.
+  echo = NULL,
   # Do not enable Reticulate jupyter_compat mode for now, see:
   # https://github.com/rstudio/reticulate/issues/1387
   # jupyter_compat = TRUE  # Reticulate enable - only show repr for last expr
-||||||| Stash base
-  eval = NA,
-  echo = NA,
   # See: https://github.com/rstudio/reticulate/issues/1387
   jupyter_compat = TRUE  # Reticulate enable - only show repr for last expr
-=======
-  # See: https://github.com/rstudio/reticulate/issues/1387
-  jupyter_compat = TRUE  # Reticulate enable - only show repr for last expr
->>>>>>> Stashed changes
 )
 
 options(dplyr.print_min = 6, dplyr.print_max = 6)
@@ -91,7 +83,7 @@ get_var = function(name) {
 
 # See: https://stackoverflow.com/questions/76732162/is-there-a-way-to-detect-the-chunk-language-when-setting-knitr-chunk-options
 set_true_for_matching_lang <- function(options, field) {
-    if (!is.logical(options[[field]])) {
+    if (is.null(options[[field]])) {
       options[[field]] <- (tolower(options$engine) == ._lang)
     }
     return (options)


### PR DESCRIPTION
Follow suggestion at original StackOverflow thread, and just check for
not-logical prior values, to see if default has been changed.  I _think_
that the values will be NULL if not set, but this just checks if they
are TRUE or FALSE, to check if they are set.