### PR TITLE
docs: fix preface typos

### DIFF
--- a/source/preface_third.Rmd
+++ b/source/preface_third.Rmd
@@ -133,9 +133,9 @@ way we analyze data, in academia, and in industry.  At the center of this
 change — was code.  Code is the language that allows us to tell the computer
 what it should do with data; it is the native language of data analysis.
 
-This insight transforms the way with think of code.  In the past, we have
+This insight transforms the way we think of code.  In the past, we have
 thought of code as a separate, specialized skill, that some of us learn.  We
-take coding courses — we "learn to code".   But if we us code as the
+take coding courses — we "learn to code".   But if we use code as the
 fundamental language for analyzing data, then we need code to express what
 data analysis does, and explain how it works.  Here we "code to learn".  Code
 is not an aim in itself, but a language we can use to express the simple ideas


### PR DESCRIPTION
Closes #170

## Summary

Fixes two typos in the same paragraph of the third edition preface:

- "way with think of code" -> "way we think of code"
- "if we us code" -> "if we use code"

Docs-only change in `source/preface_third.Rmd`.

Signed off with DCO.
